### PR TITLE
Remove invalid regex character for Firebase buckets

### DIFF
--- a/cloudcheck/providers/google.py
+++ b/cloudcheck/providers/google.py
@@ -15,9 +15,10 @@ class Google(BaseCloudProvider):
     ]
 
     bucket_name_regex = r"[a-z0-9][a-z0-9-_\.]{1,61}[a-z0-9]"
+    firebase_bucket_name_regex = r"[a-z0-9][a-z0-9-\.]{1,61}[a-z0-9]"
     regexes = {
         "STORAGE_BUCKET": [
-            r"(" + bucket_name_regex + r")\.(firebaseio\.com)",
+            r"(" + firebase_bucket_name_regex + r")\.(firebaseio\.com)",
             r"(" + bucket_name_regex + r")\.(storage\.googleapis\.com)",
         ]
     }


### PR DESCRIPTION
This pull request removes '_' (underscore) characters from the Firebase regex to prevent the generation of invalid bucket names. 

Remaining description copied from from BBOT PR: https://github.com/blacklanternsecurity/bbot/pull/1105

A Firebase datastore cannot validly have an underscore character in its name and the Firebase API returns a 403 HTTP status code if it does. The current logic expects that only a 404 status code means that the bucket does not exist. This results in buckets that cannot exist on Firebase being identified as existing where the candidate bucket names contain an underscore.

Example Firebase response where an underscore is present (and the bucket does not exist):
![1](https://github.com/blacklanternsecurity/cloudcheck/assets/73672196/0dc431c6-37d1-4b27-9f50-a6cb3e4a6fad)

Example Firebase response where no underscore is present and the bucket does not exist:
![2](https://github.com/blacklanternsecurity/cloudcheck/assets/73672196/aa29279f-96f4-43b8-92d1-857c2a16ca50)